### PR TITLE
hotfix for istio installation

### DIFF
--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -9,13 +9,15 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
-	"github.com/solo-io/solo-kit/pkg/api/v1/reporter"
+
+	//"github.com/solo-io/solo-kit/pkg/api/v1/reporter"
 	"github.com/solo-io/solo-kit/pkg/utils/contextutils"
 	"github.com/solo-io/solo-kit/pkg/utils/errutils"
 	"github.com/solo-io/solo-kit/pkg/utils/kubeutils"
 	gloov1 "github.com/solo-io/supergloo/pkg/api/external/gloo/v1"
 	istiosecret "github.com/solo-io/supergloo/pkg/api/external/istio/encryption/v1"
-	"github.com/solo-io/supergloo/pkg/api/external/istio/networking/v1alpha3"
+
+	//"github.com/solo-io/supergloo/pkg/api/external/istio/networking/v1alpha3"
 	prometheusv1 "github.com/solo-io/supergloo/pkg/api/external/prometheus/v1"
 	"github.com/solo-io/supergloo/pkg/api/v1"
 	"github.com/solo-io/supergloo/pkg/translator/consul"
@@ -38,29 +40,29 @@ func Main() error {
 		return err
 	}
 
-	destinationRuleClient, err := v1alpha3.NewDestinationRuleClient(&factory.KubeResourceClientFactory{
-		Crd:         v1alpha3.DestinationRuleCrd,
-		Cfg:         restConfig,
-		SharedCache: kubeCache,
-	})
-	if err != nil {
-		return err
-	}
-	if err := destinationRuleClient.Register(); err != nil {
-		return err
-	}
+	//destinationRuleClient, err := v1alpha3.NewDestinationRuleClient(&factory.KubeResourceClientFactory{
+	//	Crd:         v1alpha3.DestinationRuleCrd,
+	//	Cfg:         restConfig,
+	//	SharedCache: kubeCache,
+	//})
+	//if err != nil {
+	//	return err
+	//}
+	//if err := destinationRuleClient.Register(); err != nil {
+	//	return err
+	//}
 
-	virtualServiceClient, err := v1alpha3.NewVirtualServiceClient(&factory.KubeResourceClientFactory{
-		Crd:         v1alpha3.VirtualServiceCrd,
-		Cfg:         restConfig,
-		SharedCache: kubeCache,
-	})
-	if err != nil {
-		return err
-	}
-	if err := virtualServiceClient.Register(); err != nil {
-		return err
-	}
+	//virtualServiceClient, err := v1alpha3.NewVirtualServiceClient(&factory.KubeResourceClientFactory{
+	//	Crd:         v1alpha3.VirtualServiceCrd,
+	//	Cfg:         restConfig,
+	//	SharedCache: kubeCache,
+	//})
+	//if err != nil {
+	//	return err
+	//}
+	//if err := virtualServiceClient.Register(); err != nil {
+	//	return err
+	//}
 
 	prometheusClient, err := prometheusv1.NewConfigClient(&factory.KubeConfigMapClientFactory{
 		Clientset: kubeClient,
@@ -134,16 +136,16 @@ func Main() error {
 
 	translatorEmitter := v1.NewTranslatorEmitter(meshClient, routingRuleClient, upstreamClient, secretClient)
 
-	rpt := reporter.NewReporter("supergloo", meshClient.BaseClient())
+	//rpt := reporter.NewReporter("supergloo", meshClient.BaseClient())
 	writeErrs := make(chan error)
 
-	istioRoutingSyncer := &istio.MeshRoutingSyncer{
-		WriteNamespaces:           defaultNamespaces,
-		DestinationRuleReconciler: v1alpha3.NewDestinationRuleReconciler(destinationRuleClient),
-		VirtualServiceReconciler:  v1alpha3.NewVirtualServiceReconciler(virtualServiceClient),
-		Reporter:                  rpt,
-		WriteSelector:             map[string]string{"reconciler.solo.io": "supergloo.istio.routing"},
-	}
+	//istioRoutingSyncer := &istio.MeshRoutingSyncer{
+	//	WriteNamespaces:           defaultNamespaces,
+	//	DestinationRuleReconciler: v1alpha3.NewDestinationRuleReconciler(destinationRuleClient),
+	//	VirtualServiceReconciler:  v1alpha3.NewVirtualServiceReconciler(virtualServiceClient),
+	//	Reporter:                  rpt,
+	//	WriteSelector:             map[string]string{"reconciler.solo.io": "supergloo.istio.routing"},
+	//}
 
 	linkerd2PrometheusSyncer := linkerd2.NewPrometheusSyncer(kubeClient, prometheusClient)
 	istioPrometheusSyncer := istio.NewPrometheusSyncer(kubeClient, prometheusClient)
@@ -156,7 +158,7 @@ func Main() error {
 	}
 
 	translatorSyncers := v1.TranslatorSyncers{
-		istioRoutingSyncer,
+		// istioRoutingSyncer, //TODO: Routing creates istio CRDs, causing istio installation to fail. We need to figure out a solution, removing this syncer as a short-term fix.
 		istioPrometheusSyncer,
 		linkerd2PrometheusSyncer,
 		consulEncryptionSyncer,


### PR DESCRIPTION
helm must be able to create CRDs when installing the istio chart, but in routing
we proactively create istio CRDs so we can make clients for istio
resources. this is an ugly hotfix to disable the routing syncer
until we have a proper solution that allows istio installs to
succeed.