### PR TITLE
fix typo, clarify init name

### DIFF
--- a/cli/pkg/cmd/install/install.go
+++ b/cli/pkg/cmd/install/install.go
@@ -26,7 +26,7 @@ func Cmd(opts *options.Options) *cobra.Command {
 	// TODO(mitchdraft) - remove filename or apply it to something
 	pflags.StringVarP(&iop.Filename, "filename", "f", "", "filename to create resources from")
 	pflags.StringVarP(&iop.MeshType, "meshtype", "m", "", "mesh to install: istio, consul, linkerd2")
-	pflags.StringVarP(&iop.Namespace, "namespace", "n", "", "namespace install mesh into")
+	pflags.StringVarP(&iop.Namespace, "namespace", "n", "", "namespace to install mesh into")
 	pflags.BoolVar(&iop.Mtls, "mtls", false, "use MTLS")
 	pflags.StringVar(&iop.SecretRef.Name, "secret.name", "", "name of the MTLS secret")
 	pflags.StringVar(&iop.SecretRef.Namespace, "secret.namespace", "", "namespace of the MTLS secret")

--- a/cli/pkg/cmd/top.go
+++ b/cli/pkg/cmd/top.go
@@ -43,7 +43,7 @@ func App(version string) *cobra.Command {
 
 	setup.InitCache(&opts)
 
-	err := setup.Init(&opts)
+	err := setup.InitSupergloo(&opts)
 	if err != nil {
 		panic(errors.Wrap(err, "Error during initialization."))
 	}

--- a/cli/pkg/setup/setup.go
+++ b/cli/pkg/setup/setup.go
@@ -96,8 +96,8 @@ func InitCache(opts *options.Options) error {
 	return nil
 }
 
-// Check if  supergloo is running on the cluster and deploy it if it isn't
-func Init(opts *options.Options) error {
+// Check if supergloo is running on the cluster and deploy it if it isn't
+func InitSupergloo(opts *options.Options) error {
 	// Should never happen, since InitCache gets  called first, but just in case
 	if opts.Cache.KubeClient == nil {
 		if err := InitCache(opts); err != nil {


### PR DESCRIPTION
- spelling error
- rename Init to InitSupergloo
  - clarifies definition
  - "init" has special meaning so we should not use "Init" as a function name