### PR TITLE
Updated linkerd to not use hard-coded namespace

### DIFF
--- a/hack/install/linkerd2/Chart.yaml
+++ b/hack/install/linkerd2/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Linkerd2
 name: linkerd2
-version: 0.1.0
+version: 0.1.1

--- a/hack/install/linkerd2/generate.go
+++ b/hack/install/linkerd2/generate.go
@@ -1,13 +1,14 @@
-package linkerd2
+package main
 
 import (
-	"github.com/ghodss/yaml"
-	"github.com/iancoleman/strcase"
-	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/iancoleman/strcase"
+	"github.com/solo-io/solo-kit/pkg/utils/log"
 )
 
 func main() {
@@ -48,7 +49,7 @@ func (o KubeObject) Filename() string {
 	if !ok {
 		panic("kind not string")
 	}
-	return strings.Replace(strcase.ToSnake(name+kind), "-", "_", -1)+".yaml"
+	return strings.Replace(strcase.ToSnake(name+kind), "-", "_", -1) + ".yaml"
 }
 
 func writeTemplates(dir string) error {
@@ -62,7 +63,9 @@ func writeTemplates(dir string) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(filepath.Join(dir, obj.Filename()), yml, 0644)
+		ymlString := string(yml)
+		updatedYml := strings.Replace(ymlString, "namespace: linkerd", "namespace: {{ .Release.Namespace }}", -1)
+		err = ioutil.WriteFile(filepath.Join(dir, obj.Filename()), []byte(updatedYml), 0644)
 	}
 	return nil
 }
@@ -84,12 +87,7 @@ func ParseKubeManifest(manifest string) (KubeObjectList, error) {
 	return objs, nil
 }
 
-const source = `### Namespace ###
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: linkerd
-
+const source = `
 ### Service Account Controller ###
 ---
 kind: ServiceAccount

--- a/hack/install/linkerd2/templates/api_service.yaml
+++ b/hack/install/linkerd2/templates/api_service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   name: api
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: http

--- a/hack/install/linkerd2/templates/controller_deployment.yaml
+++ b/hack/install/linkerd2/templates/controller_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   name: controller
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   strategy: {}

--- a/hack/install/linkerd2/templates/grafana_config_config_map.yaml
+++ b/hack/install/linkerd2/templates/grafana_config_config_map.yaml
@@ -50,4 +50,4 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   name: grafana-config
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}

--- a/hack/install/linkerd2/templates/grafana_deployment.yaml
+++ b/hack/install/linkerd2/templates/grafana_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   name: grafana
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   strategy: {}

--- a/hack/install/linkerd2/templates/grafana_service.yaml
+++ b/hack/install/linkerd2/templates/grafana_service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   name: grafana
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: http

--- a/hack/install/linkerd2/templates/linkerd_controller_service_account.yaml
+++ b/hack/install/linkerd2/templates/linkerd_controller_service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-controller
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}

--- a/hack/install/linkerd2/templates/linkerd_linkerd_controller_cluster_role_binding.yaml
+++ b/hack/install/linkerd2/templates/linkerd_linkerd_controller_cluster_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-controller
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}

--- a/hack/install/linkerd2/templates/linkerd_linkerd_prometheus_cluster_role_binding.yaml
+++ b/hack/install/linkerd2/templates/linkerd_linkerd_prometheus_cluster_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-prometheus
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}

--- a/hack/install/linkerd2/templates/linkerd_prometheus_service_account.yaml
+++ b/hack/install/linkerd2/templates/linkerd_prometheus_service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-prometheus
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}

--- a/hack/install/linkerd2/templates/prometheus_config_config_map.yaml
+++ b/hack/install/linkerd2/templates/prometheus_config_config_map.yaml
@@ -78,4 +78,4 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   name: prometheus-config
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}

--- a/hack/install/linkerd2/templates/prometheus_deployment.yaml
+++ b/hack/install/linkerd2/templates/prometheus_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   name: prometheus
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   strategy: {}

--- a/hack/install/linkerd2/templates/prometheus_service.yaml
+++ b/hack/install/linkerd2/templates/prometheus_service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   name: prometheus
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: admin-http

--- a/hack/install/linkerd2/templates/proxy_api_service.yaml
+++ b/hack/install/linkerd2/templates/proxy_api_service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   name: proxy-api
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: grpc

--- a/hack/install/linkerd2/templates/web_deployment.yaml
+++ b/hack/install/linkerd2/templates/web_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
   name: web
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   strategy: {}

--- a/hack/install/linkerd2/templates/web_service.yaml
+++ b/hack/install/linkerd2/templates/web_service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
   name: web
-  namespace: linkerd
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: http

--- a/pkg/install/consul/consul_installer.go
+++ b/pkg/install/consul/consul_installer.go
@@ -21,10 +21,6 @@ func (c *ConsulInstaller) GetDefaultNamespace() string {
 	return defaultNamespace
 }
 
-func (c *ConsulInstaller) UseHardcodedNamespace() bool {
-	return false
-}
-
 func (c *ConsulInstaller) GetCrbName() string {
 	return CrbName
 }

--- a/pkg/install/install_syncer.go
+++ b/pkg/install/install_syncer.go
@@ -44,8 +44,6 @@ type InstallSyncer struct {
 
 type MeshInstaller interface {
 	GetDefaultNamespace() string
-	// TODO: remove when #71 is fixed
-	UseHardcodedNamespace() bool
 	GetCrbName() string
 	GetOverridesYaml(install *v1.Install) string
 	DoPreHelmInstall(installNamespace string, install *v1.Install) error
@@ -149,9 +147,6 @@ func (syncer *InstallSyncer) installHelmRelease(ctx context.Context, install *v1
 }
 
 func (syncer *InstallSyncer) SetupInstallNamespace(install *v1.Install, installer MeshInstaller) (string, error) {
-	if installer.UseHardcodedNamespace() {
-		return installer.GetDefaultNamespace(), nil
-	}
 	installNamespace := getInstallNamespace(install, installer.GetDefaultNamespace())
 	err := syncer.createNamespaceIfNotExist(installNamespace) // extract to CRD
 	if err != nil {

--- a/pkg/install/istio/istio_installer.go
+++ b/pkg/install/istio/istio_installer.go
@@ -48,10 +48,6 @@ func (c *IstioInstaller) GetDefaultNamespace() string {
 	return defaultNamespace
 }
 
-func (c *IstioInstaller) UseHardcodedNamespace() bool {
-	return false
-}
-
 func (c *IstioInstaller) GetCrbName() string {
 	return CrbName
 }

--- a/pkg/install/linkerd2/linkerd2_installer.go
+++ b/pkg/install/linkerd2/linkerd2_installer.go
@@ -6,17 +6,13 @@ import (
 )
 
 const (
-	defaultNamespace = "default" // (hard-coded to linkerd in our chart)
+	defaultNamespace = "linkerd"
 )
 
 type Linkerd2Installer struct{}
 
 func (c *Linkerd2Installer) GetDefaultNamespace() string {
 	return defaultNamespace
-}
-
-func (c *Linkerd2Installer) UseHardcodedNamespace() bool {
-	return true
 }
 
 func (c *Linkerd2Installer) GetCrbName() string {


### PR DESCRIPTION
Fixed generator to substitute {{ Release.Namespace }} where appropriate. Uploaded a new chart linkerd2-0.1.1.tgz to s3. This chart no longer provides a namespace (the install process sets that up). Updated the installer test to install to random namespace and to use this new tar. 