### PR TITLE
Appmesh cli

### DIFF
--- a/cli/pkg/cmd/create/aws_secret.go
+++ b/cli/pkg/cmd/create/aws_secret.go
@@ -1,0 +1,116 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"github.com/solo-io/supergloo/cli/pkg/cmd/options"
+	"github.com/solo-io/supergloo/cli/pkg/common"
+	gloov1 "github.com/solo-io/supergloo/pkg/api/external/gloo/v1"
+	"github.com/spf13/cobra"
+)
+
+func AwsSecretCmd(opts *options.Options) *cobra.Command {
+	sOpts := &(opts.Create).AwsSecret
+	cmd := &cobra.Command{
+		Use:   "aws-secret",
+		Short: `Create an AWS secret with the given name`,
+		Long:  `Create an AWS secret with the given name`,
+		Args:  cobra.ExactArgs(1),
+		Run: func(c *cobra.Command, args []string) {
+			// make sure the given args are valid
+			if err := validateAwsSecretArgs(opts); err != nil {
+				fmt.Println(err)
+				return
+			}
+			// gather any missing args that are available through interactive mode
+			if err := gatherAwsSecretArgs(args, opts); err != nil {
+				fmt.Println(err)
+				return
+			}
+			// create the secret
+			if err := createAwsSecret(opts); err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Printf("Created aws secret [%v] in namespace [%v]\n", args[0], sOpts.Namespace)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&sOpts.AccessKey, "access-key", "", "aws access key")
+	cmd.MarkFlagRequired("access-key")
+
+	flags.StringVar(&sOpts.SecretKey, "secret-key", "", "aws secret key")
+	cmd.MarkFlagRequired("secret-key")
+
+	flags.StringVar(&sOpts.Namespace, "secretnamespace", "", "namespace in which to store the secret")
+
+	return cmd
+}
+
+func validateAwsSecretArgs(opts *options.Options) error {
+	sOpts := &(opts.Create).AwsSecret
+	// check if we are interactive mode
+	if opts.Top.Static && sOpts.Namespace == "" {
+		return fmt.Errorf("please provide a namespace for the secret")
+	}
+	if sOpts.Namespace != "" {
+		if !common.Contains(opts.Cache.Namespaces, sOpts.Namespace) {
+			return fmt.Errorf("please provide a valid namespace for the secret. %v does not exist", sOpts.Namespace)
+		}
+	}
+	return nil
+}
+
+func gatherAwsSecretArgs(args []string, opts *options.Options) error {
+	sOpts := &(opts.Create).AwsSecret
+
+	// apply the args
+	sOpts.Name = args[0]
+
+	// check if we are interactive mode
+	if opts.Top.Static {
+		return nil
+	}
+
+	if sOpts.Namespace == "" {
+		namespace, err := common.ChooseNamespace(opts, "Select a namespace")
+		if err != nil {
+			return fmt.Errorf("input error")
+		}
+		sOpts.Namespace = namespace
+	}
+	return nil
+}
+
+func createAwsSecret(opts *options.Options) error {
+	sOpts := &(opts.Create).AwsSecret
+
+	secret := &gloov1.Secret{
+		Metadata: core.Metadata{
+			Name:      sOpts.Name,
+			Namespace: sOpts.Namespace,
+		},
+		Kind: &gloov1.Secret_Aws{
+			Aws: &gloov1.AwsSecret{
+				// these can be read in from ~/.aws/credentials by default (if user does not provide)
+				// see https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html for more details
+				AccessKey: sOpts.AccessKey,
+				SecretKey: sOpts.SecretKey,
+			},
+		},
+	}
+
+	secretClient, err := common.GetGlooSecretClient()
+	if err != nil {
+		return err
+	}
+	_, err = (*secretClient).Write(secret, clients.WriteOpts{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cli/pkg/cmd/create/aws_secret.go
+++ b/cli/pkg/cmd/create/aws_secret.go
@@ -41,10 +41,7 @@ func AwsSecretCmd(opts *options.Options) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.StringVar(&sOpts.AccessKey, "access-key", "", "aws access key")
-	cmd.MarkFlagRequired("access-key")
-
 	flags.StringVar(&sOpts.SecretKey, "secret-key", "", "aws secret key")
-	cmd.MarkFlagRequired("secret-key")
 
 	flags.StringVar(&sOpts.Namespace, "secretnamespace", "", "namespace in which to store the secret")
 
@@ -57,6 +54,15 @@ func validateAwsSecretArgs(opts *options.Options) error {
 	if opts.Top.Static && sOpts.Namespace == "" {
 		return fmt.Errorf("please provide a namespace for the secret")
 	}
+
+	if opts.Top.Static && sOpts.AccessKey == "" {
+		return fmt.Errorf("please provide an AWS access key")
+	}
+
+	if opts.Top.Static && sOpts.SecretKey == "" {
+		return fmt.Errorf("please provide an AWS secret key")
+	}
+
 	if sOpts.Namespace != "" {
 		if !common.Contains(opts.Cache.Namespaces, sOpts.Namespace) {
 			return fmt.Errorf("please provide a valid namespace for the secret. %v does not exist", sOpts.Namespace)
@@ -82,6 +88,22 @@ func gatherAwsSecretArgs(args []string, opts *options.Options) error {
 			return fmt.Errorf("input error")
 		}
 		sOpts.Namespace = namespace
+	}
+
+	if sOpts.SecretKey == "" {
+		secretKey, err := common.GetString("AWS Secret Key")
+		if err != nil {
+			return fmt.Errorf("input error")
+		}
+		sOpts.SecretKey = secretKey
+	}
+
+	if sOpts.AccessKey == "" {
+		accessKey, err := common.GetString("AWS Access Key")
+		if err != nil {
+			return fmt.Errorf("input error")
+		}
+		sOpts.AccessKey = accessKey
 	}
 	return nil
 }

--- a/cli/pkg/cmd/create/create.go
+++ b/cli/pkg/cmd/create/create.go
@@ -20,6 +20,7 @@ func Cmd(opts *options.Options) *cobra.Command {
 	cmd.AddCommand(
 		RoutingRuleCmd(opts),
 		SecretCmd(opts),
+		AwsSecretCmd(opts),
 	)
 
 	return cmd

--- a/cli/pkg/cmd/create/secret.go
+++ b/cli/pkg/cmd/create/secret.go
@@ -117,7 +117,7 @@ func createSecret(opts *options.Options) error {
 		CaCert:    string(rootCa),
 		CaKey:     string(privateKey),
 	}
-	secretClient, err := common.GetSecretClient()
+	secretClient, err := common.GetIstioSecretClient()
 	if err != nil {
 		return err
 	}

--- a/cli/pkg/cmd/get/info/mesh.go
+++ b/cli/pkg/cmd/get/info/mesh.go
@@ -44,7 +44,11 @@ func transformMesh(mesh *v1.Mesh) map[string]string {
 	meshFieldMap[meshName] = mesh.Metadata.Name
 	meshFieldMap[target], meshFieldMap[namespace] = getMeshType(mesh)
 	meshFieldMap[status] = core.Status_State_name[int32(mesh.Status.State)]
-	meshFieldMap[encryption] = strconv.FormatBool(mesh.Encryption.TlsEnabled)
+	if mesh.Encryption != nil {
+		meshFieldMap[encryption] = strconv.FormatBool(mesh.Encryption.TlsEnabled)
+	} else {
+		meshFieldMap[encryption] = strconv.FormatBool(false)
+	}
 	return meshFieldMap
 }
 

--- a/cli/pkg/cmd/install/common.go
+++ b/cli/pkg/cmd/install/common.go
@@ -56,15 +56,6 @@ func qualifyFlags(opts *options.Options) error {
 		if iop.MeshType == "" {
 			return fmt.Errorf("please provide a mesh type")
 		}
-
-		// user does not need to pass a custom secret
-		// if they do, they must pass both the name and namespace
-		if iop.SecretRef.Namespace != "" && iop.SecretRef.Name == "" {
-			return fmt.Errorf("please specify a secret name to use mTLS")
-		}
-		if iop.SecretRef.Name != "" && iop.SecretRef.Namespace == "" {
-			return fmt.Errorf("please specify a secret namespace to use mTLS")
-		}
 		return nil
 	}
 
@@ -82,6 +73,28 @@ func qualifyFlags(opts *options.Options) error {
 			return fmt.Errorf("input error")
 		}
 		iop.Namespace = namespace
+	}
+
+	if iop.MeshType == common.AppMesh {
+		if iop.AwsRegion == "" {
+			return fmt.Errorf("please specify an aws region")
+		}
+		if iop.AwsSecret.Name == "" || iop.AwsSecret.Namespace == "" {
+			return fmt.Errorf("please specify an aws secret")
+		}
+		// short-circuit, none of the remaining options are used for AppMesh
+		return nil
+	}
+
+	if top.Static {
+		// user does not need to pass a custom secret
+		// if they do, they must pass both the name and namespace
+		if iop.SecretRef.Namespace != "" && iop.SecretRef.Name == "" {
+			return fmt.Errorf("please specify a secret name")
+		}
+		if iop.SecretRef.Name != "" && iop.SecretRef.Namespace == "" {
+			return fmt.Errorf("please specify a secret namespace")
+		}
 	}
 
 	if common.Contains([]string{common.Istio, common.Linkerd2}, iop.MeshType) {

--- a/cli/pkg/cmd/install/common.go
+++ b/cli/pkg/cmd/install/common.go
@@ -13,11 +13,11 @@ import (
 	"gopkg.in/AlecAivazis/survey.v1"
 )
 
-func installationSummaryMessage(opts *options.Options) {
+func installationSummaryMessage(opts *options.Options, name string) {
 	if opts.Install.Namespace == "" {
-		fmt.Printf("Installing %v", opts.Install.MeshType)
+		fmt.Printf("Installing %v with name %s.\n", opts.Install.MeshType, name)
 	} else {
-		fmt.Printf("Installing %v in namespace %v.\n", opts.Install.MeshType, opts.Install.Namespace)
+		fmt.Printf("Installing %v in namespace %v with name %s.\n", opts.Install.MeshType, opts.Install.Namespace, name)
 	}
 
 	if opts.Install.Mtls {

--- a/cli/pkg/cmd/install/install.go
+++ b/cli/pkg/cmd/install/install.go
@@ -30,6 +30,9 @@ func Cmd(opts *options.Options) *cobra.Command {
 	pflags.BoolVar(&iop.Mtls, "mtls", false, "use mTLS")
 	pflags.StringVar(&iop.SecretRef.Name, "secret.name", "", "name of the mTLS secret")
 	pflags.StringVar(&iop.SecretRef.Namespace, "secret.namespace", "", "namespace of the mTLS secret")
+	pflags.StringVar(&iop.AwsSecretRef.Name, "awssecret.name", "", "name of the AWS secret")
+	pflags.StringVar(&iop.AwsSecretRef.Namespace, "awssecret.namespace", "", "namespace of the AWS secret")
+	pflags.StringVar(&iop.AwsRegion, "aws-region", "", "AWS region")
 	return cmd
 }
 

--- a/cli/pkg/cmd/install/install.go
+++ b/cli/pkg/cmd/install/install.go
@@ -60,28 +60,30 @@ func install(opts *options.Options) {
 		installSpec = generateLinkerd2InstallSpecFromOpts(opts)
 	}
 
+	var name string
 	// App mesh is a special case that is installed in the translator syncer, until we refactor install syncer to allow non-helm installs
 	if opts.Install.MeshType == "appmesh" {
-		installAppMesh(opts)
+		name, err = installAppMesh(opts)
 	} else {
 		_, err = (*installClient).Write(installSpec, clients.WriteOpts{})
+		name = installSpec.Metadata.Name
 	}
 
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	installationSummaryMessage(opts)
+	installationSummaryMessage(opts, name)
 	return
 }
 
-func installAppMesh(opts *options.Options) error {
+func installAppMesh(opts *options.Options) (string, error) {
 	meshClient, err := common.GetMeshClient()
 	if err != nil {
 		fmt.Println(err)
-		return err
+		return "", err
 	}
 	mesh := generateAppMeshInstallSpecFromOpts(opts)
 	_, err = (*meshClient).Write(mesh, clients.WriteOpts{})
-	return err
+	return mesh.Metadata.Name, err
 }

--- a/cli/pkg/cmd/install/install.go
+++ b/cli/pkg/cmd/install/install.go
@@ -25,7 +25,7 @@ func Cmd(opts *options.Options) *cobra.Command {
 	pflags := cmd.PersistentFlags()
 	// TODO(mitchdraft) - remove filename or apply it to something
 	pflags.StringVarP(&iop.Filename, "filename", "f", "", "filename to create resources from")
-	pflags.StringVarP(&iop.MeshType, "meshtype", "m", "", "mesh to install: istio, consul, linkerd2")
+	pflags.StringVarP(&iop.MeshType, "meshtype", "m", "", "mesh to install: istio, consul, linkerd2, appmesh")
 	pflags.StringVarP(&iop.Namespace, "namespace", "n", "", "namespace to install mesh into")
 	pflags.BoolVar(&iop.Mtls, "mtls", false, "use mTLS")
 	pflags.StringVar(&iop.SecretRef.Name, "secret.name", "", "name of the mTLS secret")
@@ -57,11 +57,28 @@ func install(opts *options.Options) {
 		installSpec = generateLinkerd2InstallSpecFromOpts(opts)
 	}
 
-	_, err = (*installClient).Write(installSpec, clients.WriteOpts{})
+	// App mesh is a special case that is installed in the translator syncer, until we refactor install syncer to allow non-helm installs
+	if opts.Install.MeshType == "appmesh" {
+		installAppMesh(opts)
+	} else {
+		_, err = (*installClient).Write(installSpec, clients.WriteOpts{})
+	}
+
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	installationSummaryMessage(opts)
 	return
+}
+
+func installAppMesh(opts *options.Options) error {
+	meshClient, err := common.GetMeshClient()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	mesh := generateAppMeshInstallSpecFromOpts(opts)
+	_, err = (*meshClient).Write(mesh, clients.WriteOpts{})
+	return err
 }

--- a/cli/pkg/cmd/install/specific.go
+++ b/cli/pkg/cmd/install/specific.go
@@ -78,7 +78,7 @@ func generateAppMeshInstallSpecFromOpts(opts *options.Options) *v1.Mesh {
 		MeshType: &v1.Mesh_AppMesh{
 			AppMesh: &v1.AppMesh{
 				AwsRegion:      opts.Install.AwsRegion,
-				AwsCredentials: &opts.Install.AwsSecret,
+				AwsCredentials: &opts.Install.AwsSecretRef,
 			},
 		},
 	}

--- a/cli/pkg/cmd/install/specific.go
+++ b/cli/pkg/cmd/install/specific.go
@@ -72,6 +72,19 @@ func generateLinkerd2InstallSpecFromOpts(opts *options.Options) *v1.Install {
 	return installSpec
 }
 
+func generateAppMeshInstallSpecFromOpts(opts *options.Options) *v1.Mesh {
+	installSpec := &v1.Mesh{
+		Metadata: getMetadataFromOpts(opts),
+		MeshType: &v1.Mesh_AppMesh{
+			AppMesh: &v1.AppMesh{
+				AwsRegion:      opts.Install.AwsRegion,
+				AwsCredentials: &opts.Install.AwsSecret,
+			},
+		},
+	}
+	return installSpec
+}
+
 func chooseWatchNamespaces(opts *options.Options) ([]string, error) {
 
 	prompt := &survey.MultiSelect{

--- a/cli/pkg/cmd/options/types.go
+++ b/cli/pkg/cmd/options/types.go
@@ -30,7 +30,7 @@ type Install struct {
 	WatchNamespaces     []string
 	ConsulServerAddress string
 	AwsRegion           string
-	AwsSecret           core.ResourceRef
+	AwsSecretRef        core.ResourceRef
 
 	// Interactive only (not passable via flags)
 	UseCustomSecret bool

--- a/cli/pkg/cmd/options/types.go
+++ b/cli/pkg/cmd/options/types.go
@@ -29,6 +29,8 @@ type Install struct {
 	SecretRef           core.ResourceRef
 	WatchNamespaces     []string
 	ConsulServerAddress string
+	AwsRegion           string
+	AwsSecret           core.ResourceRef
 
 	// Interactive only (not passable via flags)
 	UseCustomSecret bool
@@ -135,9 +137,10 @@ type NsResourceMap map[string]*NsResource
 // *the association is by the namespace in which the CRD is installed, unless otherwise noted.
 type NsResource struct {
 	// keyed by namespace containing the CRD
-	Meshes    []string
-	Secrets   []string
-	Upstreams []string
+	Meshes       []string
+	IstioSecrets []string
+	GlooSecrets  []string
+	Upstreams    []string
 
 	// keyed by mesh installation namespace
 	// purpose of this list: allows user to select a mesh by the namespace in which they installed the mesh

--- a/cli/pkg/cmd/options/types.go
+++ b/cli/pkg/cmd/options/types.go
@@ -98,9 +98,17 @@ type Secret struct {
 	Name       string
 }
 
+type AwsSecret struct {
+	AccessKey string
+	SecretKey string
+	Namespace string
+	Name      string
+}
+
 type Create struct {
 	RoutingRule RoutingRule
 	Secret      Secret
+	AwsSecret   AwsSecret
 }
 
 type Config struct {

--- a/cli/pkg/common/clients.go
+++ b/cli/pkg/common/clients.go
@@ -35,9 +35,23 @@ func GetUpstreamClient() (*glooV1.UpstreamClient, error) {
 	return &upstreamClient, nil
 }
 
-func GetSecretClient() (*istiosecret.IstioCacertsSecretClient, error) {
+func GetIstioSecretClient() (*istiosecret.IstioCacertsSecretClient, error) {
 	clientset, err := GetKubernetesClient()
 	secretClient, err := factory2.GetIstioCacertsSecretClient(clientset)
+	if err != nil {
+		return nil, err
+	}
+	if err = secretClient.Register(); err != nil {
+		return nil, err
+	}
+	return &secretClient, nil
+}
+
+func GetGlooSecretClient() (*glooV1.SecretClient, error) {
+	clientset, err := GetKubernetesClient()
+	secretClient, err := glooV1.NewSecretClient(&factory.KubeSecretClientFactory{
+		Clientset: clientset,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/common/constants.go
+++ b/cli/pkg/common/constants.go
@@ -9,6 +9,7 @@ const (
 	Istio    = "istio"
 	Consul   = "consul"
 	Linkerd2 = "linkerd2"
+	AppMesh  = "appmesh"
 
 	// The character used as a separator when specifying CLI options that are to be interpreted as a list of values
 	ListOptionSeparator = ","

--- a/cli/pkg/common/survey.go
+++ b/cli/pkg/common/survey.go
@@ -42,3 +42,9 @@ func ChooseBool(message string) (bool, error) {
 
 	return choice == yes, nil
 }
+
+func GetString(message string) (string, error) {
+	var str string
+	err := survey.AskOne(&survey.Input{Message: message}, &str, survey.Required)
+	return str, err
+}

--- a/cli/pkg/nsutil/gen_map.go
+++ b/cli/pkg/nsutil/gen_map.go
@@ -56,9 +56,12 @@ func generateCommonResourceSelectOptions(typeName string, nsrMap options.NsResou
 		var resArray []string
 		switch typeName {
 		case "secret":
-			resArray = nsr.Secrets
+			resArray = nsr.IstioSecrets
 		case "upstream":
 			resArray = nsr.Upstreams
+		case "awssecret":
+			// TODO: the secret mappings here use the proto name in the resource map, and translate to a user facing name based on the use case. cleanup?
+			resArray = nsr.GlooSecrets
 		default:
 			panic(fmt.Errorf("resource type %v not recognized", typeName))
 		}

--- a/cli/pkg/nsutil/gen_map_test.go
+++ b/cli/pkg/nsutil/gen_map_test.go
@@ -1,6 +1,7 @@
 package nsutil
 
 import (
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/supergloo/cli/pkg/cmd/options"
 
 	. "github.com/onsi/ginkgo"
@@ -10,20 +11,20 @@ import (
 var _ = Describe("Generate Options", func() {
 	nsrMap := make(options.NsResourceMap)
 	nsrMap["ns1"] = &options.NsResource{
-		Meshes:  []string{"m1", "m2"},
-		Secrets: []string{"s1", "s2"},
-		MeshesByInstallNs: []options.ResourceRef{
-			options.ResourceRef{
+		Meshes:      []string{"m1", "m2"},
+		GlooSecrets: []string{"s1", "s2"},
+		MeshesByInstallNs: []core.ResourceRef{
+			{
 				Name:      "m1",
 				Namespace: "ns1",
 			},
 		},
 	}
 	nsrMap["ns2"] = &options.NsResource{
-		Meshes:  []string{},
-		Secrets: []string{"s3"},
-		MeshesByInstallNs: []options.ResourceRef{
-			options.ResourceRef{
+		Meshes:      []string{},
+		GlooSecrets: []string{"s3"},
+		MeshesByInstallNs: []core.ResourceRef{
+			{
 				Name:      "m2",
 				Namespace: "ns1",
 			},
@@ -41,7 +42,7 @@ var _ = Describe("Generate Options", func() {
 		expectedMap["ns1, m1"] = ResSelect{
 			displayName:      "m1",
 			displayNamespace: "ns1",
-			resourceRef: options.ResourceRef{
+			resourceRef: core.ResourceRef{
 				Name:      "m1",
 				Namespace: "ns1",
 			},
@@ -49,7 +50,7 @@ var _ = Describe("Generate Options", func() {
 		expectedMap["ns2, m2"] = ResSelect{
 			displayName:      "m2",
 			displayNamespace: "ns2",
-			resourceRef: options.ResourceRef{
+			resourceRef: core.ResourceRef{
 				Name:      "m2",
 				Namespace: "ns1",
 			},
@@ -68,7 +69,7 @@ var _ = Describe("Generate Options", func() {
 		expectedMap["ns1, s1"] = ResSelect{
 			displayName:      "s1",
 			displayNamespace: "ns1",
-			resourceRef: options.ResourceRef{
+			resourceRef: core.ResourceRef{
 				Name:      "s1",
 				Namespace: "ns1",
 			},
@@ -76,7 +77,7 @@ var _ = Describe("Generate Options", func() {
 		expectedMap["ns1, s2"] = ResSelect{
 			displayName:      "s2",
 			displayNamespace: "ns1",
-			resourceRef: options.ResourceRef{
+			resourceRef: core.ResourceRef{
 				Name:      "s2",
 				Namespace: "ns1",
 			},
@@ -84,7 +85,7 @@ var _ = Describe("Generate Options", func() {
 		expectedMap["ns2, s3"] = ResSelect{
 			displayName:      "s3",
 			displayNamespace: "ns2",
-			resourceRef: options.ResourceRef{
+			resourceRef: core.ResourceRef{
 				Name:      "s3",
 				Namespace: "ns2",
 			},

--- a/cli/pkg/nsutil/select.go
+++ b/cli/pkg/nsutil/select.go
@@ -109,19 +109,26 @@ func validateResourceRefForStaticMode(typeName string, menuDescription string, r
 			return fmt.Errorf("Please specify a valid namespace. Namespace %v not found.", resRef.Namespace)
 		}
 
+		refError := fmt.Errorf("Please specify a valid %v name. %v not found in namespace %v.", resRef.Name, menuDescription, resRef.Namespace)
+
 		// make sure that the particular resource exists in the specified namespace
 		switch typeName {
 		case "mesh":
 			if !common.Contains(opts.Cache.NsResources[resRef.Namespace].Meshes, resRef.Name) {
-				return fmt.Errorf("Please specify a valid %v name. %v not found in namespace %v.", resRef.Name, menuDescription, resRef.Namespace)
+				return refError
 			}
+		// TODO: clean up the mapping for secrets, which is made in several places
 		case "secret":
-			if !common.Contains(opts.Cache.NsResources[resRef.Namespace].Secrets, resRef.Name) {
-				return fmt.Errorf("Please specify a valid %v name. %v not found in namespace %v.", resRef.Name, menuDescription, resRef.Namespace)
+			if !common.Contains(opts.Cache.NsResources[resRef.Namespace].IstioSecrets, resRef.Name) {
+				return refError
+			}
+		case "awssecret":
+			if !common.Contains(opts.Cache.NsResources[resRef.Namespace].GlooSecrets, resRef.Name) {
+				return refError
 			}
 		case "upstream":
 			if !common.Contains(opts.Cache.NsResources[resRef.Namespace].Upstreams, resRef.Name) {
-				return fmt.Errorf("Please specify a valid %v name. %v not found in namespace %v.", resRef.Name, menuDescription, resRef.Namespace)
+				return refError
 			}
 		default:
 			panic(fmt.Errorf("typename %v not recognized", typeName))

--- a/cli/pkg/setup/setup.go
+++ b/cli/pkg/setup/setup.go
@@ -124,14 +124,15 @@ func InitCache(opts *options.Options) error {
 			case *superglooV1.Mesh_Istio:
 				iNs = spec.Istio.InstallationNamespace
 			}
-			opts.Cache.NsResources[iNs].MeshesByInstallNs = append(
-				opts.Cache.NsResources[iNs].MeshesByInstallNs,
-				core.ResourceRef{
-					Name:      m.Metadata.Name,
-					Namespace: m.Metadata.Namespace,
-				})
+			if iNs != "" {
+				opts.Cache.NsResources[iNs].MeshesByInstallNs = append(
+					opts.Cache.NsResources[iNs].MeshesByInstallNs,
+					core.ResourceRef{
+						Name:      m.Metadata.Name,
+						Namespace: m.Metadata.Namespace,
+					})
+			}
 		}
-
 	}
 
 	return nil

--- a/cli/pkg/setup/setup.go
+++ b/cli/pkg/setup/setup.go
@@ -47,7 +47,11 @@ func InitCache(opts *options.Options) error {
 	if err != nil {
 		return err
 	}
-	secretClient, err := common.GetSecretClient()
+	istioSecretClient, err := common.GetIstioSecretClient()
+	if err != nil {
+		return err
+	}
+	glooSecretClient, err := common.GetGlooSecretClient()
 	if err != nil {
 		return err
 	}
@@ -67,13 +71,21 @@ func InitCache(opts *options.Options) error {
 		for _, m := range meshList {
 			meshes = append(meshes, m.Metadata.Name)
 		}
-		secretList, err := (*secretClient).List(ns, clients.ListOpts{})
+		istioSecretList, err := (*istioSecretClient).List(ns, clients.ListOpts{})
 		if err != nil {
 			return err
 		}
-		var secrets = []string{}
-		for _, m := range secretList {
-			secrets = append(secrets, m.Metadata.Name)
+		var istioSecrets = []string{}
+		for _, m := range istioSecretList {
+			istioSecrets = append(istioSecrets, m.Metadata.Name)
+		}
+		glooSecretList, err := (*glooSecretClient).List(ns, clients.ListOpts{})
+		if err != nil {
+			return err
+		}
+		var glooSecrets = []string{}
+		for _, m := range glooSecretList {
+			glooSecrets = append(glooSecrets, m.Metadata.Name)
 		}
 		upstreamList, err := (*upstreamClient).List(ns, clients.ListOpts{})
 		if err != nil {
@@ -89,7 +101,8 @@ func InitCache(opts *options.Options) error {
 		opts.Cache.NsResources[ns] = &options.NsResource{
 			MeshesByInstallNs: meshesByInstallNs,
 			Meshes:            meshes,
-			Secrets:           secrets,
+			IstioSecrets:      istioSecrets,
+			GlooSecrets:       glooSecrets,
 			Upstreams:         upstreams,
 		}
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,6 +2,6 @@ package constants
 
 var (
 	SuperglooNamespace = "supergloo-system"
-	MeshOptions        = []string{"istio", "consul", "linkerd2"}
+	MeshOptions        = []string{"istio", "consul", "linkerd2", "appmesh"}
 	ConsulInstallPath  = "https://github.com/hashicorp/consul-helm/archive/v0.3.0.tar.gz"
 )


### PR DESCRIPTION
Static and interactive CLI commands for creating AWS secrets and installing AWS app mesh

Example commands: 
```
supergloo create aws-secret test --access-key foo --secret-key bar --secretnamespace supergloo-system
supergloo install -m appmesh --awssecret.name test --awssecret.namespace supergloo-system --aws-region us-east-1
```

Then see what got created: 
```
[13:51:36] rick@Ricks-MacBook-Pro:~/code/src/github.com/solo-io/supergloo$ supergloo get meshes
NAME              NAMESPACE    TARGET-MESH    STATUS
appmesh-dkzmq0                                Pending
```