### PR TITLE
Fail fast if we cannot connect to the kubernetes cluster

### DIFF
--- a/cli/pkg/cmd/initsupergloo/initsupergloo.go
+++ b/cli/pkg/cmd/initsupergloo/initsupergloo.go
@@ -12,8 +12,8 @@ import (
 func Cmd(opts *options.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: `Initialize supergloo.`,
-		Long:  `Initialize supergloo.`,
+		Short: `Initialize supergloo`,
+		Long:  `Initialize supergloo`,
 		Run: func(c *cobra.Command, args []string) {
 			initsupergloo()
 		},

--- a/cli/pkg/cmd/uninstall/uninstall.go
+++ b/cli/pkg/cmd/uninstall/uninstall.go
@@ -17,9 +17,7 @@ func Cmd(opts *options.Options) *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			uninstall(opts)
 		},
-
 	}
-
 
 	uop := &opts.Uninstall
 	pflags := cmd.PersistentFlags()
@@ -43,7 +41,6 @@ func uninstall(opts *options.Options) {
 		fmt.Println(err)
 		return
 	}
-
 
 	return
 }

--- a/cli/pkg/common/clients.go
+++ b/cli/pkg/common/clients.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"time"
 
 	factory2 "github.com/solo-io/supergloo/pkg/factory"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func GetUpstreamClient() (*glooV1.UpstreamClient, error) {
-	config, err := GetKubernetesConfig()
+	config, err := GetKubernetesConfig(0)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +49,7 @@ func GetSecretClient() (*istiosecret.IstioCacertsSecretClient, error) {
 }
 
 func GetMeshClient() (*superglooV1.MeshClient, error) {
-	config, err := GetKubernetesConfig()
+	config, err := GetKubernetesConfig(0)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +68,7 @@ func GetMeshClient() (*superglooV1.MeshClient, error) {
 }
 
 func GetRoutingRuleClient() (*superglooV1.RoutingRuleClient, error) {
-	config, err := GetKubernetesConfig()
+	config, err := GetKubernetesConfig(0)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func GetInstallClient() (*superglooV1.InstallClient, error) {
 }
 
 func GetKubernetesClient() (*kubernetes.Clientset, error) {
-	config, err := GetKubernetesConfig()
+	config, err := GetKubernetesConfig(0)
 	if err != nil {
 		return nil, err
 	}
@@ -118,10 +119,11 @@ func GetKubernetesClient() (*kubernetes.Clientset, error) {
 	return kubeClient, nil
 }
 
-func GetKubernetesConfig() (*rest.Config, error) {
+func GetKubernetesConfig(timeout time.Duration) (*rest.Config, error) {
 	config, err := kubeutils.GetConfig("", "")
 	if err != nil {
 		return nil, fmt.Errorf(KubeConfigError, err)
 	}
+	config.Timeout = timeout
 	return config, nil
 }

--- a/cli/pkg/setup/setup.go
+++ b/cli/pkg/setup/setup.go
@@ -1,17 +1,17 @@
 package setup
 
 import (
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"github.com/solo-io/supergloo/cli/pkg/cmd/options"
-	"github.com/solo-io/supergloo/cli/pkg/common"
-	superglooV1 "github.com/solo-io/supergloo/pkg/api/v1"
-
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"github.com/solo-io/supergloo/cli/pkg/cmd/options"
+	"github.com/solo-io/supergloo/cli/pkg/common"
+	superglooV1 "github.com/solo-io/supergloo/pkg/api/v1"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
@@ -21,6 +21,23 @@ import (
 	kubecore "k8s.io/api/core/v1"
 	kubemeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// Checks whether the cluster that the kubeconfig points at is available
+// The timeout for the kubernetes client is set to a low value to notify the user of the failure
+func CheckConnection() error {
+	config, err := common.GetKubernetesConfig(time.Second)
+	if err != nil {
+		return err
+	}
+	kube, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	_, err = kube.CoreV1().Namespaces().List(kubemeta.ListOptions{})
+
+	return err
+}
 
 func InitCache(opts *options.Options) error {
 	// Get a kube client
@@ -126,7 +143,7 @@ func InitCache(opts *options.Options) error {
 
 // Check if supergloo is running on the cluster and deploy it if it isn't
 func InitSupergloo(opts *options.Options) error {
-	// Should never happen, since InitCache gets  called first, but just in case
+	// Should never happen, since InitCache gets called first, but just in case
 	if opts.Cache.KubeClient == nil {
 		if err := InitCache(opts); err != nil {
 			return err


### PR DESCRIPTION
Since we currently do not set any timeouts on our kubernetes clients, it takes the CLI a long time before returning an error in case the kubeconfig is not pointing to a running cluster. This is frustrating for the user.

I added a connection attempt with a 1s timeout before we start our usual init steps to avoid this.