### PR TITLE
fix case where labels are empty, bump discovery version

### DIFF
--- a/hack/install/supergloo.yaml
+++ b/hack/install/supergloo.yaml
@@ -48,20 +48,23 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: supergloo
+    gloo: discovery
   name: discovery
   namespace: supergloo-system
-  labels:
-    gloo: discovery
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      supergloo: discovery
   template:
     metadata:
       labels:
-        gloo: discovery
+        supergloo: discovery
     spec:
       containers:
-      - name: supergloo
-        image: soloio/discovery:dev
-        imagePullPolicy: IfNotPresent
-        args:
-        - -udsonly
+        - image: "soloio/discovery:0.6.14"
+          imagePullPolicy: Always
+          name: discovery
+          args: ["--namespace=supergloo-system" ]


### PR DESCRIPTION
currently discovery is misconfigured and set to an old version in the install yaml

this fixes discovery to deploy properly and scan all namespaces
also fixes an edge case where a service has no labels and it causes the routing syncer to write invalid destination rules
