### PR TITLE
prevent reinstalling istio if the user options have not changed

### DIFF
--- a/pkg/install/istio/install_istio.go
+++ b/pkg/install/istio/install_istio.go
@@ -122,6 +122,11 @@ func (i *defaultIstioInstaller) installOrUpdateIstio(ctx context.Context, opts i
 		manifests[i] = m
 	}
 
+	// nothing to do if the manifest hasn't changed
+	if opts.previousInstall.CombinedString() == manifests.CombinedString() {
+		return manifests, nil
+	}
+
 	// perform upgrade instead
 	if len(opts.previousInstall) > 0 {
 		if err := i.helmInstaller.UpdateFromManifests(ctx, namespace, opts.previousInstall, manifests, true); err != nil {


### PR DESCRIPTION
until now, if the install crd is re-read, install syncer performs an Update every time (which the helm lib is not smart enough to do a no-op with).

this pr prevents calling Update unless the manifests have changed