### PR TITLE
List all AWS App Mesh API resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -130,7 +130,7 @@
   version = "v2.2.0"
 
 [[projects]]
-  digest = "1:bac7fc3890504b2f4ce95a5277836ac7c0c653534c23569d03967eedcb0d8a86"
+  digest = "1:db59f043a93c944991296451eb6b4137388cfe1ff91a272942d43767d4793c7d"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -170,8 +170,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "f9b35e02297c8fcca7a55dd30ed8d4e9dc64f5a3"
-  version = "v1.18.5"
+  revision = "c44180fe5d17e41f3aa22bdea42c073b344bcaac"
+  version = "v1.19.17"
 
 [[projects]]
   branch = "master"
@@ -2556,6 +2556,7 @@
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/yaml",

--- a/changelog/v0.3.14/list-all-appmesh-resources.yaml
+++ b/changelog/v0.3.14/list-all-appmesh-resources.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Added function to list all AWS App Mesh API resources for a particular mesh.

--- a/pkg/config/appmesh/appmesh_suite_test.go
+++ b/pkg/config/appmesh/appmesh_suite_test.go
@@ -1,0 +1,16 @@
+package appmesh_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var T *testing.T
+
+func TestAppmesh(t *testing.T) {
+	RegisterFailHandler(Fail)
+	T = t
+	RunSpecs(t, "Appmesh Suite")
+}

--- a/pkg/config/appmesh/client.go
+++ b/pkg/config/appmesh/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-//go:generate mockgen -destination=./client_mock.go -source client.go -package appmesh
+//go:generate mockgen -destination=./mocks/client_mock.go -source client.go -package appmesh
 
 // Represents the App Mesh API
 type Client interface {
@@ -26,16 +26,16 @@ type Client interface {
 
 	// Create operations
 	CreateMesh(ctx context.Context, meshName string) (*appmesh.MeshData, error)
-	CreateVirtualNode(ctx context.Context, virtualNode appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error)
-	CreateVirtualService(ctx context.Context, virtualService appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error)
-	CreateVirtualRouter(ctx context.Context, virtualRouter appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error)
-	CreateRoute(ctx context.Context, route appmesh.RouteData) (*appmesh.RouteData, error)
+	CreateVirtualNode(ctx context.Context, virtualNode *appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error)
+	CreateVirtualService(ctx context.Context, virtualService *appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error)
+	CreateVirtualRouter(ctx context.Context, virtualRouter *appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error)
+	CreateRoute(ctx context.Context, route *appmesh.RouteData) (*appmesh.RouteData, error)
 
 	// Update operations
-	UpdateVirtualNode(ctx context.Context, virtualNode appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error)
-	UpdateVirtualService(ctx context.Context, virtualService appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error)
-	UpdateVirtualRouter(ctx context.Context, virtualRouter appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error)
-	UpdateRoute(ctx context.Context, route appmesh.RouteData) (*appmesh.RouteData, error)
+	UpdateVirtualNode(ctx context.Context, virtualNode *appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error)
+	UpdateVirtualService(ctx context.Context, virtualService *appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error)
+	UpdateVirtualRouter(ctx context.Context, virtualRouter *appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error)
+	UpdateRoute(ctx context.Context, route *appmesh.RouteData) (*appmesh.RouteData, error)
 
 	// Delete operations
 	DeleteMesh(ctx context.Context, meshName string) error
@@ -196,7 +196,7 @@ func (c *client) CreateMesh(ctx context.Context, meshName string) (*appmesh.Mesh
 	}
 }
 
-func (c *client) CreateVirtualNode(ctx context.Context, vn appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
+func (c *client) CreateVirtualNode(ctx context.Context, vn *appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
 	input := &appmesh.CreateVirtualNodeInput{
 		MeshName:        vn.MeshName,
 		VirtualNodeName: vn.VirtualNodeName,
@@ -212,7 +212,7 @@ func (c *client) CreateVirtualNode(ctx context.Context, vn appmesh.VirtualNodeDa
 	}
 }
 
-func (c *client) CreateVirtualService(ctx context.Context, vs appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
+func (c *client) CreateVirtualService(ctx context.Context, vs *appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
 	input := &appmesh.CreateVirtualServiceInput{
 		MeshName:           vs.MeshName,
 		VirtualServiceName: vs.VirtualServiceName,
@@ -228,7 +228,7 @@ func (c *client) CreateVirtualService(ctx context.Context, vs appmesh.VirtualSer
 	}
 }
 
-func (c *client) CreateVirtualRouter(ctx context.Context, vr appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
+func (c *client) CreateVirtualRouter(ctx context.Context, vr *appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
 	input := &appmesh.CreateVirtualRouterInput{
 		MeshName:          vr.MeshName,
 		VirtualRouterName: vr.VirtualRouterName,
@@ -244,7 +244,7 @@ func (c *client) CreateVirtualRouter(ctx context.Context, vr appmesh.VirtualRout
 	}
 }
 
-func (c *client) CreateRoute(ctx context.Context, route appmesh.RouteData) (*appmesh.RouteData, error) {
+func (c *client) CreateRoute(ctx context.Context, route *appmesh.RouteData) (*appmesh.RouteData, error) {
 	input := &appmesh.CreateRouteInput{
 		MeshName:          route.MeshName,
 		RouteName:         route.RouteName,
@@ -263,7 +263,7 @@ func (c *client) CreateRoute(ctx context.Context, route appmesh.RouteData) (*app
 	}
 }
 
-func (c *client) UpdateVirtualNode(ctx context.Context, vn appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
+func (c *client) UpdateVirtualNode(ctx context.Context, vn *appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
 	input := &appmesh.UpdateVirtualNodeInput{
 		MeshName:        vn.MeshName,
 		VirtualNodeName: vn.VirtualNodeName,
@@ -279,7 +279,7 @@ func (c *client) UpdateVirtualNode(ctx context.Context, vn appmesh.VirtualNodeDa
 	}
 }
 
-func (c *client) UpdateVirtualService(ctx context.Context, vs appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
+func (c *client) UpdateVirtualService(ctx context.Context, vs *appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
 	input := &appmesh.UpdateVirtualServiceInput{
 		MeshName:           vs.MeshName,
 		VirtualServiceName: vs.VirtualServiceName,
@@ -295,7 +295,7 @@ func (c *client) UpdateVirtualService(ctx context.Context, vs appmesh.VirtualSer
 	}
 }
 
-func (c *client) UpdateVirtualRouter(ctx context.Context, vr appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
+func (c *client) UpdateVirtualRouter(ctx context.Context, vr *appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
 	input := &appmesh.UpdateVirtualRouterInput{
 		MeshName:          vr.MeshName,
 		VirtualRouterName: vr.VirtualRouterName,
@@ -311,7 +311,7 @@ func (c *client) UpdateVirtualRouter(ctx context.Context, vr appmesh.VirtualRout
 	}
 }
 
-func (c *client) UpdateRoute(ctx context.Context, route appmesh.RouteData) (*appmesh.RouteData, error) {
+func (c *client) UpdateRoute(ctx context.Context, route *appmesh.RouteData) (*appmesh.RouteData, error) {
 	input := &appmesh.UpdateRouteInput{
 		MeshName:          route.MeshName,
 		RouteName:         route.RouteName,

--- a/pkg/config/appmesh/client_builder.go
+++ b/pkg/config/appmesh/client_builder.go
@@ -11,7 +11,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
-//go:generate mockgen -destination=./client_builder_mock.go -source client_builder.go -package appmesh
+//go:generate mockgen -destination=./mocks/client_builder_mock.go -source client_builder.go -package appmesh
 
 func NewAppMeshClientBuilder(secrets gloov1.SecretClient) ClientBuilder {
 	return &clientBuilder{

--- a/pkg/config/appmesh/list_all.go
+++ b/pkg/config/appmesh/list_all.go
@@ -1,0 +1,149 @@
+package appmesh
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/solo-io/go-utils/errors"
+)
+
+type Resources struct {
+	VirtualNodes, VirtualServices []string
+	VirtualRouters                map[string][]string
+}
+
+func ListAllForMesh(ctx context.Context, client Client, meshName string) (*Resources, error) {
+
+	type virtualRouter struct {
+		name       string
+		routeNames []string
+	}
+
+	var (
+		requestWg           sync.WaitGroup
+		virtualNodesChan    = make(chan []string, 10)
+		virtualServicesChan = make(chan []string, 10)
+		virtualRouterChan   = make(chan virtualRouter, 10)
+		errorChan           = make(chan error, 10)
+		collectWg           sync.WaitGroup
+		vnNames,
+		vsNames []string
+		virtualRouters = make(map[string][]string)
+		err            *multierror.Error
+	)
+
+	// Virtual Nodes
+	requestWg.Add(1)
+	go func() {
+		defer requestWg.Done()
+
+		vNodes, err := client.ListVirtualNodes(ctx, meshName)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		virtualNodesChan <- vNodes
+	}()
+
+	// Virtual Services
+	requestWg.Add(1)
+	go func() {
+		defer requestWg.Done()
+
+		vServices, err := client.ListVirtualServices(ctx, meshName)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		virtualServicesChan <- vServices
+	}()
+
+	// Virtual Routers
+	requestWg.Add(1)
+	go func() {
+		defer requestWg.Done()
+
+		// Get all virtual routers
+		vRouters, err := client.ListVirtualRouters(ctx, meshName)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+
+		// Get the routes for each virtual router
+		var routeWg sync.WaitGroup
+		for _, vr := range vRouters {
+			routeWg.Add(1)
+
+			go func(vrName string) {
+				defer routeWg.Done()
+
+				routes, err := client.ListRoutes(ctx, meshName, vrName)
+				if err != nil {
+					errorChan <- err
+					return
+				} else {
+					virtualRouterChan <- virtualRouter{name: vrName, routeNames: routes}
+				}
+			}(vr)
+		}
+		routeWg.Wait()
+	}()
+
+	// Close channels when all workers have finished
+	go func() {
+		requestWg.Wait()
+		close(virtualNodesChan)
+		close(virtualServicesChan)
+		close(virtualRouterChan)
+		close(errorChan)
+	}()
+
+	// Collect the results
+	// Each `range` statement will block until the correspondent channel is closed
+	collectWg.Add(1)
+	go func() {
+		defer collectWg.Done()
+		for vn := range virtualNodesChan {
+			vnNames = vn
+		}
+	}()
+
+	collectWg.Add(1)
+	go func() {
+		defer collectWg.Done()
+		for vs := range virtualServicesChan {
+			vsNames = vs
+		}
+	}()
+
+	collectWg.Add(1)
+	go func() {
+		defer collectWg.Done()
+		for vr := range virtualRouterChan {
+			virtualRouters[vr.name] = vr.routeNames
+		}
+	}()
+
+	collectWg.Add(1)
+	go func() {
+		defer collectWg.Done()
+		for e := range errorChan {
+			err = multierror.Append(err, e)
+		}
+	}()
+
+	// Wait on resource collection to finish
+	collectWg.Wait()
+
+	if mergedError := err.ErrorOrNil(); mergedError != nil {
+		return nil, errors.Wrapf(mergedError, "failed to list all App Mesh resources for mesh %s", meshName)
+	}
+
+	return &Resources{
+		VirtualNodes:    vnNames,
+		VirtualServices: vsNames,
+		VirtualRouters:  virtualRouters,
+	}, nil
+}

--- a/pkg/config/appmesh/list_all_test.go
+++ b/pkg/config/appmesh/list_all_test.go
@@ -1,0 +1,118 @@
+package appmesh_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/solo-io/go-utils/errors"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	mocks "github.com/solo-io/supergloo/pkg/config/appmesh/mocks"
+
+	. "github.com/solo-io/supergloo/pkg/config/appmesh"
+)
+
+var _ = Describe("List all App Mesh resources", func() {
+
+	var (
+		ctrl *gomock.Controller
+		mesh = "test-mesh"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(T)
+		defer ctrl.Finish()
+	})
+
+	It("correctly lists all resources for a mesh", func() {
+		mockClient := mocks.NewMockClient(ctrl)
+		mockClient.EXPECT().ListVirtualNodes(gomock.Any(), mesh).DoAndReturn(returnWithDelay("vn-1", "vn-2", "vn-3")).Times(1)
+		mockClient.EXPECT().ListVirtualServices(gomock.Any(), mesh).DoAndReturn(returnWithDelay("vs-1", "vs-2", "vs-3")).Times(1)
+		mockClient.EXPECT().ListVirtualRouters(gomock.Any(), mesh).DoAndReturn(returnWithDelay("vr-1", "vr-2")).Times(1)
+		mockClient.EXPECT().ListRoutes(gomock.Any(), mesh, "vr-1").DoAndReturn(returnRoutesWithDelay("vr1-route-1")).Times(1)
+		mockClient.EXPECT().ListRoutes(gomock.Any(), mesh, "vr-2").DoAndReturn(returnRoutesWithDelay("vr2-route-1", "vr2-route-2")).Times(1)
+
+		resources, err := ListAllForMesh(context.TODO(), mockClient, mesh)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources).NotTo(BeNil())
+
+		Expect(resources.VirtualNodes).To(ConsistOf("vn-1", "vn-2", "vn-3"))
+		Expect(resources.VirtualServices).To(ConsistOf("vs-1", "vs-2", "vs-3"))
+
+		Expect(resources.VirtualRouters).To(HaveLen(2))
+
+		routesVr1, ok := resources.VirtualRouters["vr-1"]
+		Expect(ok).To(BeTrue())
+		Expect(routesVr1).To(ConsistOf("vr1-route-1"))
+
+		routesVr2, ok := resources.VirtualRouters["vr-2"]
+		Expect(ok).To(BeTrue())
+		Expect(routesVr2).To(ConsistOf("vr2-route-1", "vr2-route-2"))
+	})
+
+	It("fails if an error occurs in any call to the underlying client", func() {
+		mockClient := mocks.NewMockClient(ctrl)
+		mockClient.EXPECT().ListVirtualNodes(gomock.Any(), mesh).DoAndReturn(returnWithDelay("vn-1", "vn-2", "vn-3")).Times(1)
+		mockClient.EXPECT().ListVirtualServices(gomock.Any(), mesh).DoAndReturn(failWithDelay()).Times(1)
+		mockClient.EXPECT().ListVirtualRouters(gomock.Any(), mesh).DoAndReturn(returnWithDelay("vr-1", "vr-2")).Times(1)
+		mockClient.EXPECT().ListRoutes(gomock.Any(), mesh, "vr-1").DoAndReturn(returnRoutesWithDelay("vr1-route-1")).Times(1)
+		mockClient.EXPECT().ListRoutes(gomock.Any(), mesh, "vr-2").DoAndReturn(returnRoutesWithDelay("vr2-route-1", "vr2-route-2")).Times(1)
+
+		_, err := ListAllForMesh(context.TODO(), mockClient, mesh)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to list all App Mesh resources for mesh test-mesh"))
+		Expect(err.Error()).To(ContainSubstring("1 error occurred"))
+		Expect(err.Error()).To(ContainSubstring("simulating failure"))
+	})
+
+	It("fails and logs correctly if multiple errors occurs in calls to the underlying client", func() {
+		mockClient := mocks.NewMockClient(ctrl)
+		mockClient.EXPECT().ListVirtualNodes(gomock.Any(), mesh).DoAndReturn(returnWithDelay("vn-1", "vn-2", "vn-3")).Times(1)
+		mockClient.EXPECT().ListVirtualServices(gomock.Any(), mesh).DoAndReturn(failWithDelay()).Times(1)
+		mockClient.EXPECT().ListVirtualRouters(gomock.Any(), mesh).DoAndReturn(returnWithDelay("vr-1", "vr-2")).Times(1)
+		mockClient.EXPECT().ListRoutes(gomock.Any(), mesh, "vr-1").DoAndReturn(failRoutesWithDelay()).Times(1)
+		mockClient.EXPECT().ListRoutes(gomock.Any(), mesh, "vr-2").DoAndReturn(returnRoutesWithDelay("vr2-route-1", "vr2-route-2")).Times(1)
+
+		_, err := ListAllForMesh(context.TODO(), mockClient, mesh)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to list all App Mesh resources for mesh test-mesh"))
+		Expect(err.Error()).To(ContainSubstring("2 errors occurred"))
+		Expect(err.Error()).To(ContainSubstring("simulating failure"))
+		Expect(err.Error()).To(ContainSubstring("simulating failure on route"))
+	})
+})
+
+// Represents the signature of ListVirtualNode/ListVirtualServices/ListVirtualRouters functions
+type listVnVsVrFunc func(ctx context.Context, mesh string) ([]string, error)
+
+// Represents the signature of ListRoutes function
+type listRoutesFunc func(ctx context.Context, mesh, vr string) ([]string, error)
+
+var returnWithDelay = func(names ...string) listVnVsVrFunc {
+	return func(context.Context, string) ([]string, error) {
+		time.Sleep(time.Duration(rand.IntnRange(50, 500)) * time.Millisecond)
+		return names, nil
+	}
+}
+var returnRoutesWithDelay = func(routeNames ...string) listRoutesFunc {
+	return func(context.Context, string, string) ([]string, error) {
+		time.Sleep(time.Duration(rand.IntnRange(50, 500)) * time.Millisecond)
+		return routeNames, nil
+	}
+}
+
+var failWithDelay = func() listVnVsVrFunc {
+	return func(context.Context, string) ([]string, error) {
+		time.Sleep(time.Duration(rand.IntnRange(50, 500)) * time.Millisecond)
+		return nil, errors.Errorf("simulating failure")
+	}
+}
+var failRoutesWithDelay = func() listRoutesFunc {
+	return func(context.Context, string, string) ([]string, error) {
+		time.Sleep(time.Duration(rand.IntnRange(50, 500)) * time.Millisecond)
+		return nil, errors.Errorf("simulating failure on route")
+	}
+}

--- a/pkg/config/appmesh/mocks/client_builder_mock.go
+++ b/pkg/config/appmesh/mocks/client_builder_mock.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	appmesh "github.com/solo-io/supergloo/pkg/config/appmesh"
 )
 
 // MockClientBuilder is a mock of ClientBuilder interface
@@ -35,10 +36,10 @@ func (m *MockClientBuilder) EXPECT() *MockClientBuilderMockRecorder {
 }
 
 // GetClientInstance mocks base method
-func (m *MockClientBuilder) GetClientInstance(secretRef *core.ResourceRef, region string) (Client, error) {
+func (m *MockClientBuilder) GetClientInstance(secretRef *core.ResourceRef, region string) (appmesh.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClientInstance", secretRef, region)
-	ret0, _ := ret[0].(Client)
+	ret0, _ := ret[0].(appmesh.Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/config/appmesh/mocks/client_mock.go
+++ b/pkg/config/appmesh/mocks/client_mock.go
@@ -141,7 +141,7 @@ func (mr *MockClientMockRecorder) CreateMesh(ctx, meshName interface{}) *gomock.
 }
 
 // CreateVirtualNode mocks base method
-func (m *MockClient) CreateVirtualNode(ctx context.Context, virtualNode appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
+func (m *MockClient) CreateVirtualNode(ctx context.Context, virtualNode *appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVirtualNode", ctx, virtualNode)
 	ret0, _ := ret[0].(*appmesh.VirtualNodeData)
@@ -156,7 +156,7 @@ func (mr *MockClientMockRecorder) CreateVirtualNode(ctx, virtualNode interface{}
 }
 
 // CreateVirtualService mocks base method
-func (m *MockClient) CreateVirtualService(ctx context.Context, virtualService appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
+func (m *MockClient) CreateVirtualService(ctx context.Context, virtualService *appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVirtualService", ctx, virtualService)
 	ret0, _ := ret[0].(*appmesh.VirtualServiceData)
@@ -171,7 +171,7 @@ func (mr *MockClientMockRecorder) CreateVirtualService(ctx, virtualService inter
 }
 
 // CreateVirtualRouter mocks base method
-func (m *MockClient) CreateVirtualRouter(ctx context.Context, virtualRouter appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
+func (m *MockClient) CreateVirtualRouter(ctx context.Context, virtualRouter *appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVirtualRouter", ctx, virtualRouter)
 	ret0, _ := ret[0].(*appmesh.VirtualRouterData)
@@ -186,7 +186,7 @@ func (mr *MockClientMockRecorder) CreateVirtualRouter(ctx, virtualRouter interfa
 }
 
 // CreateRoute mocks base method
-func (m *MockClient) CreateRoute(ctx context.Context, route appmesh.RouteData) (*appmesh.RouteData, error) {
+func (m *MockClient) CreateRoute(ctx context.Context, route *appmesh.RouteData) (*appmesh.RouteData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRoute", ctx, route)
 	ret0, _ := ret[0].(*appmesh.RouteData)
@@ -201,7 +201,7 @@ func (mr *MockClientMockRecorder) CreateRoute(ctx, route interface{}) *gomock.Ca
 }
 
 // UpdateVirtualNode mocks base method
-func (m *MockClient) UpdateVirtualNode(ctx context.Context, virtualNode appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
+func (m *MockClient) UpdateVirtualNode(ctx context.Context, virtualNode *appmesh.VirtualNodeData) (*appmesh.VirtualNodeData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateVirtualNode", ctx, virtualNode)
 	ret0, _ := ret[0].(*appmesh.VirtualNodeData)
@@ -216,7 +216,7 @@ func (mr *MockClientMockRecorder) UpdateVirtualNode(ctx, virtualNode interface{}
 }
 
 // UpdateVirtualService mocks base method
-func (m *MockClient) UpdateVirtualService(ctx context.Context, virtualService appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
+func (m *MockClient) UpdateVirtualService(ctx context.Context, virtualService *appmesh.VirtualServiceData) (*appmesh.VirtualServiceData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateVirtualService", ctx, virtualService)
 	ret0, _ := ret[0].(*appmesh.VirtualServiceData)
@@ -231,7 +231,7 @@ func (mr *MockClientMockRecorder) UpdateVirtualService(ctx, virtualService inter
 }
 
 // UpdateVirtualRouter mocks base method
-func (m *MockClient) UpdateVirtualRouter(ctx context.Context, virtualRouter appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
+func (m *MockClient) UpdateVirtualRouter(ctx context.Context, virtualRouter *appmesh.VirtualRouterData) (*appmesh.VirtualRouterData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateVirtualRouter", ctx, virtualRouter)
 	ret0, _ := ret[0].(*appmesh.VirtualRouterData)
@@ -246,7 +246,7 @@ func (mr *MockClientMockRecorder) UpdateVirtualRouter(ctx, virtualRouter interfa
 }
 
 // UpdateRoute mocks base method
-func (m *MockClient) UpdateRoute(ctx context.Context, route appmesh.RouteData) (*appmesh.RouteData, error) {
+func (m *MockClient) UpdateRoute(ctx context.Context, route *appmesh.RouteData) (*appmesh.RouteData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRoute", ctx, route)
 	ret0, _ := ret[0].(*appmesh.RouteData)


### PR DESCRIPTION
Added a function that concurrently calls the `List` functions for each App Mesh resource types and aggregates the results.

This will be used in the App Mesh reconciler (follow-up PR).