### PR TITLE
Webhook config defaults

### DIFF
--- a/changelog/v0.3.16/webhook-defaults.yaml
+++ b/changelog/v0.3.16/webhook-defaults.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    descrition: Add consistent behavior for defaulting missing sidecar injection configuration values.

--- a/cli/pkg/cmd/register/app_mesh.go
+++ b/cli/pkg/cmd/register/app_mesh.go
@@ -3,8 +3,6 @@ package register
 import (
 	"strings"
 
-	"github.com/solo-io/supergloo/pkg/util"
-
 	"github.com/solo-io/supergloo/cli/pkg/helpers"
 
 	"github.com/pkg/errors"
@@ -132,18 +130,6 @@ func validateFlags(opts *options.Options) error {
 
 	if opts.RegisterAppMesh.VirtualNodeLabel == "" {
 		return errors.Errorf("you must provide a virtual node label if auto-injection is enabled")
-	}
-
-	// TODO(marco): temporary fix, otherwise current version of webhook will fail
-	if opts.RegisterAppMesh.ConfigMap.Name == "" || opts.RegisterAppMesh.ConfigMap.Namespace == "" {
-
-		// Get the namespace in which supergloo is running
-		superglooNamespace, err := util.GetSuperglooNamespace(clients.MustKubeClient())
-		if err != nil {
-			return err
-		}
-		opts.RegisterAppMesh.ConfigMap.Namespace = superglooNamespace
-		opts.RegisterAppMesh.ConfigMap.Name = "sidecar-injector"
 	}
 
 	return nil

--- a/pkg/registration/appmesh/reconcile.go
+++ b/pkg/registration/appmesh/reconcile.go
@@ -122,9 +122,8 @@ func (r *autoInjectionReconciler) renderAutoInjectionManifests(namespace string)
 		ServerCertKey: base64.StdEncoding.EncodeToString(certs.serverCertKey),
 		CaBundle:      base64.StdEncoding.EncodeToString(certs.caCertificate),
 		Image: Image{
-			Name: webhookImageName,
-			// TODO(EItanya): default to something other than undefined
-			Tag:        version.Version,
+			Name:       webhookImageName,
+			Tag:        version.GetWebhookImageTag(),
 			PullPolicy: webhookImagePullPolicy,
 		},
 	}

--- a/pkg/registration/appmesh/reconcile_test.go
+++ b/pkg/registration/appmesh/reconcile_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Reconciler", func() {
 					Expect(deployment.Name).To(BeEquivalentTo(webhookName))
 					containers := deployment.Spec.Template.Spec.Containers
 					Expect(containers).To(HaveLen(1))
-					Expect(containers[0].Image).To(BeEquivalentTo(fmt.Sprintf("%s:%s", webhookImageName, version.Version)))
+					Expect(containers[0].Image).To(BeEquivalentTo(fmt.Sprintf("%s:%s", webhookImageName, version.GetWebhookImageTag())))
 					Expect(containers[0].ImagePullPolicy).To(BeEquivalentTo(webhookImagePullPolicy))
 					volumes := deployment.Spec.Template.Spec.Volumes
 					Expect(volumes).To(HaveLen(1))

--- a/pkg/registration/appmesh/syncer_test.go
+++ b/pkg/registration/appmesh/syncer_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Syncer", func() {
 		ctx = context.Background()
 
 		// Create the config map containing the manifests for the auto-injection resources
-		configMap := &corev1.ConfigMap{}
+		autoInjectionResourcesConfigMap := &corev1.ConfigMap{}
 		cm, err := ioutil.ReadFile("test/test-sidecar-injector-configmap.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(yaml.Unmarshal(cm, configMap)).NotTo(HaveOccurred())
-		_, err = kube.CoreV1().ConfigMaps(testNamespace).Create(configMap)
+		Expect(yaml.Unmarshal(cm, autoInjectionResourcesConfigMap)).NotTo(HaveOccurred())
+		_, err = kube.CoreV1().ConfigMaps(testNamespace).Create(autoInjectionResourcesConfigMap)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Mock AWS client
@@ -346,10 +346,6 @@ var mesh = &v1.Mesh{
 				},
 			},
 			VirtualNodeLabel: "vn",
-			SidecarPatchConfigMap: &core.ResourceRef{
-				Namespace: testNamespace,
-				Name:      webhookName,
-			},
 		},
 	},
 }

--- a/pkg/registration/appmesh/validate_test.go
+++ b/pkg/registration/appmesh/validate_test.go
@@ -3,6 +3,9 @@ package appmesh
 import (
 	"context"
 
+	v12 "k8s.io/api/core/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/aws/aws-sdk-go/service/appmesh"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -41,6 +44,8 @@ var _ = Describe("Validate App Mesh meshes", func() {
 		secretClient.EXPECT().Read(testNamespace, gomock.Not("aws-secret"), gomock.Any()).Return(nil, errors.New("error")).AnyTimes()
 
 		kube = fake.NewSimpleClientset()
+		_, err := kube.CoreV1().ConfigMaps(testNamespace).Create(&v12.ConfigMap{ObjectMeta: v13.ObjectMeta{Namespace: testNamespace, Name: webhookName}})
+		Expect(err).NotTo(HaveOccurred())
 
 		validator = NewAppMeshValidator(kube, secretClient)
 	})

--- a/pkg/registration/appmesh/validate_test.go
+++ b/pkg/registration/appmesh/validate_test.go
@@ -3,8 +3,8 @@ package appmesh
 import (
 	"context"
 
-	v12 "k8s.io/api/core/v1"
-	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/aws-sdk-go/service/appmesh"
 	"github.com/golang/mock/gomock"
@@ -44,7 +44,7 @@ var _ = Describe("Validate App Mesh meshes", func() {
 		secretClient.EXPECT().Read(testNamespace, gomock.Not("aws-secret"), gomock.Any()).Return(nil, errors.New("error")).AnyTimes()
 
 		kube = fake.NewSimpleClientset()
-		_, err := kube.CoreV1().ConfigMaps(testNamespace).Create(&v12.ConfigMap{ObjectMeta: v13.ObjectMeta{Namespace: testNamespace, Name: webhookName}})
+		_, err := kube.CoreV1().ConfigMaps(testNamespace).Create(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: webhookName}})
 		Expect(err).NotTo(HaveOccurred())
 
 		validator = NewAppMeshValidator(kube, secretClient)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,3 +13,11 @@ var (
 func IsReleaseVersion() bool {
 	return Version != UndefinedVersion && Version != DevVersion
 }
+
+func GetWebhookImageTag() string {
+	defaultTag := "latest"
+	if IsReleaseVersion() {
+		defaultTag = Version
+	}
+	return defaultTag
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,7 +15,8 @@ func IsReleaseVersion() bool {
 }
 
 func GetWebhookImageTag() string {
-	defaultTag := "latest"
+	// TODO(marco): temporarily default to a manually tagged image to make tests pass. Each build will soon build and push its own images.
+	defaultTag := "temporary-for-tests"
 	if IsReleaseVersion() {
 		defaultTag = Version
 	}

--- a/pkg/webhook/clients/clientset.go
+++ b/pkg/webhook/clients/clientset.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/solo-io/supergloo/pkg/util"
+
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -21,6 +23,7 @@ import (
 type WebhookResourceClient interface {
 	ListMeshes(namespace string, opts clients.ListOpts) (v1.MeshList, error)
 	GetConfigMap(namespace, name string) (*corev1.ConfigMap, error)
+	GetSuperglooNamespace() (string, error)
 }
 
 // Contains the resource clients required by the webhook
@@ -35,6 +38,10 @@ func (c *webhookClientSet) ListMeshes(namespace string, opts clients.ListOpts) (
 
 func (c *webhookClientSet) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
 	return c.kubeClient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+}
+
+func (c *webhookClientSet) GetSuperglooNamespace() (string, error) {
+	return util.GetSuperglooNamespace(c.kubeClient)
 }
 
 var (

--- a/pkg/webhook/clients/clientset_mock.go
+++ b/pkg/webhook/clients/clientset_mock.go
@@ -65,3 +65,18 @@ func (mr *MockWebhookResourceClientMockRecorder) GetConfigMap(namespace, name in
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockWebhookResourceClient)(nil).GetConfigMap), namespace, name)
 }
+
+// GetSuperglooNamespace mocks base method
+func (m *MockWebhookResourceClient) GetSuperglooNamespace() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSuperglooNamespace")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSuperglooNamespace indicates an expected call of GetSuperglooNamespace
+func (mr *MockWebhookResourceClientMockRecorder) GetSuperglooNamespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuperglooNamespace", reflect.TypeOf((*MockWebhookResourceClient)(nil).GetSuperglooNamespace))
+}

--- a/pkg/webhook/test/resources.go
+++ b/pkg/webhook/test/resources.go
@@ -129,7 +129,7 @@ var appMeshInjectEnabledLabelSelector = &v1.Mesh{
 			VirtualNodeLabel: "virtual-node",
 			EnableAutoInject: true,
 			SidecarPatchConfigMap: &core.ResourceRef{
-				Name:      "sidecar-injector-webhook-configmap",
+				Name:      "sidecar-injector",
 				Namespace: "supergloo-system",
 			},
 			InjectionSelector: &v1.PodSelector{
@@ -149,7 +149,7 @@ var appMeshInjectEnabledNamespaceSelector = &v1.Mesh{
 			VirtualNodeLabel: "virtual-node",
 			EnableAutoInject: true,
 			SidecarPatchConfigMap: &core.ResourceRef{
-				Name:      "sidecar-injector-webhook-configmap",
+				Name:      "sidecar-injector",
 				Namespace: "supergloo-system",
 			},
 			InjectionSelector: &v1.PodSelector{
@@ -168,7 +168,7 @@ var appMeshInjectDisabled = &v1.Mesh{
 			VirtualNodeLabel: "virtual-node",
 			EnableAutoInject: false,
 			SidecarPatchConfigMap: &core.ResourceRef{
-				Name:      "sidecar-injector-webhook-configmap",
+				Name:      "sidecar-injector",
 				Namespace: "supergloo-system",
 			},
 			InjectionSelector: &v1.PodSelector{
@@ -204,7 +204,7 @@ var appMeshNoSelector = &v1.Mesh{
 			VirtualNodeLabel: "virtual-node",
 			EnableAutoInject: true,
 			SidecarPatchConfigMap: &core.ResourceRef{
-				Name:      "sidecar-injector-webhook-configmap",
+				Name:      "sidecar-injector",
 				Namespace: "supergloo-system"}}}}
 
 var istioMesh = &v1.Mesh{

--- a/test/e2e/appmesh/e2e_test.go
+++ b/test/e2e/appmesh/e2e_test.go
@@ -53,9 +53,8 @@ var _ = Describe("E2e", func() {
 func testRegisterAppmesh(meshName, secretName string) {
 	region, vnLabel := "us-east-1", "app"
 	err := utils.Supergloo(fmt.Sprintf("register appmesh --name %s --region %s "+
-		"--secret %s.%s --select-namespaces %s --virtual-node-label %s --configmap %s.%s",
-		meshName, region, superglooNamespace, secretName, namespaceWithInject, vnLabel,
-		superglooNamespace, "sidecar-injector"))
+		"--secret %s.%s --select-namespaces %s --virtual-node-label %s",
+		meshName, region, superglooNamespace, secretName, namespaceWithInject, vnLabel))
 	Expect(err).NotTo(HaveOccurred())
 
 	meshClient := clients.MustMeshClient()


### PR DESCRIPTION
Two fixes:
1. Default webhook image tag to `latest`
2. Do not set a default value for the `SidecarPatchConfigMap` resource ref on the mesh object, but rather let it be `nil` and have whoever needs it determine the correct default.