### PR TITLE
Add TAGGED_VERSION env to GCB steps

### DIFF
--- a/changelog/v0.3.23/fix-cloud-build-config.yaml
+++ b/changelog/v0.3.23/fix-cloud-build-config.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Update the cloudbuild.yaml to add the TAGGED_VERSION env to all steps that require it.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,6 +38,7 @@ steps:
       - 'PROJECT_ROOT=github.com/solo-io/supergloo'
       - 'GOPATH=/workspace/gopath'
       - 'BUILD_ID=$BUILD_ID'
+      - 'TAGGED_VERSION=$TAG_NAME'
     dir: './gopath/src/github.com/solo-io/supergloo'
     entrypoint: make
     args: ['check-format']
@@ -65,6 +66,7 @@ steps:
       - 'PROJECT_ROOT=github.com/solo-io/supergloo'
       - 'GOPATH=/workspace/gopath'
       - 'BUILD_ID=$BUILD_ID'
+      - 'TAGGED_VERSION=$TAG_NAME'
       - 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
       - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
       - 'CLOUDSDK_CONTAINER_CLUSTER=supergloo-test'
@@ -82,6 +84,7 @@ steps:
       - 'PROJECT_ROOT=github.com/solo-io/supergloo'
       - 'GOPATH=/workspace/gopath'
       - 'BUILD_ID=$BUILD_ID'
+      - 'TAGGED_VERSION=$TAG_NAME'
       - 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
       - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
       - 'CLOUDSDK_CONTAINER_CLUSTER=supergloo-test'
@@ -217,6 +220,7 @@ steps:
     env:
       - 'PROJECT_ROOT=github.com/solo-io/supergloo'
       - 'GOPATH=/workspace/gopath'
+      - 'TAGGED_VERSION=$TAG_NAME'
       - 'BUILD_ID=$BUILD_ID'
       - 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
       - 'KUBECONFIG=/builder/home/.kube/aws-config'
@@ -234,6 +238,7 @@ steps:
       - 'PROJECT_ROOT=github.com/solo-io/supergloo'
       - 'GOPATH=/workspace/gopath'
       - 'BUILD_ID=$BUILD_ID'
+      - 'TAGGED_VERSION=$TAG_NAME'
       - 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
     dir: './gopath/src/github.com/solo-io/supergloo'
     entrypoint: sh
@@ -247,6 +252,7 @@ steps:
       - 'PROJECT_ROOT=github.com/solo-io/supergloo'
       - 'GOPATH=/workspace/gopath'
       - 'BUILD_ID=$BUILD_ID'
+      - 'TAGGED_VERSION=$TAG_NAME'
       - 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
       - 'KUBECONFIG=/builder/home/.kube/istio-10x-config'
       - 'ISTIO_VERSION=1.0.6'
@@ -263,6 +269,7 @@ steps:
       - 'PROJECT_ROOT=github.com/solo-io/supergloo'
       - 'GOPATH=/workspace/gopath'
       - 'BUILD_ID=$BUILD_ID'
+      - 'TAGGED_VERSION=$TAG_NAME'
       - 'KUBECONFIG=/builder/home/.kube/linkerd-config'
       - 'E2E_RUN_PODS_LOCALLY=1'
     dir: './gopath/src/github.com/solo-io/supergloo'


### PR DESCRIPTION
Release builds were failing because the TAGGED_VERSION env wasn't being passed to the e2e build steps. This caused the e2e tests to look for the build assets in the test repositories, while the previous (correctly configured) `docker` and `manifest` steps had pushed them to the release ones.